### PR TITLE
Update Docker image version and add latest tag in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,4 +27,6 @@ jobs:
         with:
           context: .
           push: true
-          tags: ghcr.io/${{ github.repository }}/dockerhub-cleanup-action:${{ github.ref_name }}
+          tags: |
+            ghcr.io/${{ github.repository }}/dockerhub-cleanup-action:${{ github.ref_name }}
+            ghcr.io/${{ github.repository }}/dockerhub-cleanup-action:latest

--- a/action.yml
+++ b/action.yml
@@ -50,4 +50,4 @@ inputs:
 
 runs:
   using: 'docker'
-  image: 'ghcr.io/maxisam/dockerhub-cleanup/dockerhub-cleanup-action:latest'
+  image: 'ghcr.io/maxisam/dockerhub-cleanup/dockerhub-cleanup-action:v0.1.3'


### PR DESCRIPTION
Update the Docker image version to v0.1.3 in the action configuration and add a 'latest' tag to the Docker image in the release workflow.